### PR TITLE
Add missing dynamic CSP img-src for custom domain

### DIFF
--- a/Plugin/CspObserverPlugin.php
+++ b/Plugin/CspObserverPlugin.php
@@ -56,6 +56,12 @@ class CspObserverPlugin
             return [$observer];
         }
 
+        $imgPolicy = $this->fetchPolicyFactory->create([
+            'id' => 'img-src',
+            'hostSources' => [$customDomain],
+            'noneAllowed' => false,
+        ]);
+
         $scriptPolicy = $this->fetchPolicyFactory->create([
             'id' => 'script-src',
             'hostSources' => [$customDomain],
@@ -68,6 +74,7 @@ class CspObserverPlugin
             'noneAllowed' => false,
         ]);
 
+        $this->dynamicCollector->add($imgPolicy);
         $this->dynamicCollector->add($scriptPolicy);
         $this->dynamicCollector->add($connectPolicy);
         return [$observer];


### PR DESCRIPTION
I noticed when debugging a checkout tracking issue that your module was also creating a link that appears to resolve as a GIF MIME type so i believe the CSP rule should also be in place for img-src.