### PR TITLE
Fix: AddToCartComplete crashes on grouped products

### DIFF
--- a/Observer/AddToCartComplete.php
+++ b/Observer/AddToCartComplete.php
@@ -95,8 +95,12 @@ class AddToCartComplete implements ObserverInterface
         /** @var \Magento\Catalog\Model\Product $product */
         $product = $observer->getData('product');
 
-        /** @var \Magento\Quote\Model\Quote\Item $quote */
+        /** @var \Magento\Quote\Model\Quote\Item|false $quoteItem */
         $quoteItem = $this->checkoutSession->getQuote()->getItemByProduct($product);
+
+        if (!$quoteItem || !is_object($quoteItem)) {
+            return;
+        }
 
         $qty = (int)$observer->getData('request')->getParam('qty');
         if ($qty === 0) {


### PR DESCRIPTION
## Problem

Adding a **grouped product** to the cart causes a fatal PHP error:

```
Error: Call to a member function getHasChildren() on bool
in Observer/AddToCartComplete.php
```

### Root Cause

In `AddToCartComplete::execute()`, the observer calls:

```php
$quoteItem = $this->checkoutSession->getQuote()->getItemByProduct($product);
```

For grouped products, Magento adds each child item as a separate quote item — there is no single quote item matching the parent grouped product. `getItemByProduct()` returns `false` (a boolean). The observer then calls `$quoteItem->getHasChildren()` on `false`, which crashes.

## Fix

Added a guard clause to return early when `$quoteItem` is not a valid object:

```php
if (!$quoteItem || !is_object($quoteItem)) {
    return;
}
```

This prevents the fatal error. The `add_to_cart` data layer event will not fire for grouped products with this change, but the cart operation completes successfully.

## How to reproduce

1. Create a grouped product with multiple child items.
2. Navigate to the grouped product page.
3. Set quantities for one or more child items.
4. Click "Add to Cart".
5. Observe the fatal error in `exception.log`.

## Tested on

- Magento 2.4.x
- PHP 8.1
- Module version 1.0.30 and current `main`